### PR TITLE
feat(nes): add support for NES registry

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -2,10 +2,10 @@
   <info organisation="com.example" module="my-spring4-app" />
 
   <dependencies>
-    <dependency org="org.springframework" name="spring-core" rev="4.3.30.RELEASE" />
-    <dependency org="org.springframework" name="spring-webmvc" rev="4.3.30.RELEASE" />
-    <dependency org="org.springframework.security" name="spring-security-core" rev="4.2.20.RELEASE" />
-    <dependency org="org.springframework.security" name="spring-security-web" rev="4.2.20.RELEASE" />
+    <dependency org="com.herodevs.nes.springframework" name="spring-core" rev="4.3.30-spring-framework-4.3.41" />
+    <dependency org="com.herodevs.nes.springframework" name="spring-webmvc" rev="4.3.30-spring-framework-4.3.41" />
+    <dependency org="com.herodevs.nes.springframework.security" name="spring-security-core" rev="4.2.20-spring-security-4.2.21" />
+    <dependency org="com.herodevs.nes.springframework.security" name="spring-security-web" rev="4.2.20-spring-security-4.2.21" />
     <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
   </dependencies>
 </ivy-module>

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -1,8 +1,11 @@
 <ivysettings>
     <settings defaultResolver="chain"/>
+    <property name="nes.password" value="${env.NES_ACCESS_TOKEN}"/>
+    <credentials host="registry.nes.herodevs.com" realm="NES" username="ivy" passwd="${nes.password}"/>
     <resolvers>
         <chain name="chain">
             <ibiblio name="central" m2compatible="true"/>
+            <ibiblio name="herodevs-nes-registry" m2compatible="true" root="https://registry.nes.herodevs.com/maven/"/>
         </chain>
     </resolvers>
 </ivysettings>


### PR DESCRIPTION
Note that to switch to HeroDevs NES for Spring packages, Ivy projects just need to update their dependencies and add our `registry.nes.herodevs.com/maven/` repository to your `ivysettings.xml`.